### PR TITLE
Add continuous corner style to rounded buttons in macOS 10.15 and up

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,15 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2228A52F2501343A00981867 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2228A52E2501343A00981867 /* Utilities.swift */; };
 		E30303402336989400B8ED1F /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E303033E2336989400B8ED1F /* CustomButton.swift */; };
-		E30303412336989400B8ED1F /* util.swift in Sources */ = {isa = PBXBuildFile; fileRef = E303033F2336989400B8ED1F /* util.swift */; };
 		E3A01E872336904F00C54787 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A01E862336904F00C54787 /* AppDelegate.swift */; };
 		E3A01E8C2336905000C54787 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = E3A01E8A2336905000C54787 /* MainMenu.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2228A52E2501343A00981867 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		E303033E2336989400B8ED1F /* CustomButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
-		E303033F2336989400B8ED1F /* util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = util.swift; sourceTree = "<group>"; };
 		E3A01E832336904F00C54787 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3A01E862336904F00C54787 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E3A01E8B2336905000C54787 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -38,7 +38,7 @@
 			isa = PBXGroup;
 			children = (
 				E303033E2336989400B8ED1F /* CustomButton.swift */,
-				E303033F2336989400B8ED1F /* util.swift */,
+				2228A52E2501343A00981867 /* Utilities.swift */,
 			);
 			name = CustomButton;
 			path = ../../Sources/CustomButton;
@@ -145,7 +145,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E30303412336989400B8ED1F /* util.swift in Sources */,
+				2228A52F2501343A00981867 /* Utilities.swift in Sources */,
 				E30303402336989400B8ED1F /* CustomButton.swift in Sources */,
 				E3A01E872336904F00C54787 /* AppDelegate.swift in Sources */,
 			);

--- a/Sources/CustomButton/CustomButton.swift
+++ b/Sources/CustomButton/CustomButton.swift
@@ -42,6 +42,14 @@ open class CustomButton: NSButton {
 		}
 	}
 
+    @IBInspectable public var hasContinuousCorners: Bool = true {
+        didSet {
+            if #available(OSX 10.15, *) {
+                layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
+            }
+        }
+    }
+
 	@IBInspectable public var borderWidth: Double = 0 {
 		didSet {
 			layer?.borderWidth = CGFloat(borderWidth)
@@ -189,6 +197,10 @@ open class CustomButton: NSButton {
 		layer?.backgroundColor = isOn ? activeBackgroundColor.cgColor : backgroundColor.cgColor
 		layer?.borderColor = isOn ? activeBorderColor.cgColor : borderColor.cgColor
 		layer?.shadowColor = isOn ? (activeShadowColor?.cgColor ?? shadowColor.cgColor) : shadowColor.cgColor
+
+        if #available(OSX 10.15, *) {
+            layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
+        }
 
 		titleLayer.alignmentMode = .center
 		titleLayer.contentsScale = window?.backingScaleFactor ?? 2

--- a/Sources/CustomButton/CustomButton.swift
+++ b/Sources/CustomButton/CustomButton.swift
@@ -44,7 +44,7 @@ open class CustomButton: NSButton {
 
 	@IBInspectable public var hasContinuousCorners: Bool = true {
 		didSet {
-			if #available(OSX 10.15, *) {
+			if #available(macOS 10.15, *) {
 				layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
 			}
 		}
@@ -198,7 +198,7 @@ open class CustomButton: NSButton {
 		layer?.borderColor = isOn ? activeBorderColor.cgColor : borderColor.cgColor
 		layer?.shadowColor = isOn ? (activeShadowColor?.cgColor ?? shadowColor.cgColor) : shadowColor.cgColor
 
-		if #available(OSX 10.15, *) {
+		if #available(macOS 10.15, *) {
 			layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
 		}
 

--- a/Sources/CustomButton/CustomButton.swift
+++ b/Sources/CustomButton/CustomButton.swift
@@ -42,13 +42,13 @@ open class CustomButton: NSButton {
 		}
 	}
 
-    @IBInspectable public var hasContinuousCorners: Bool = true {
-        didSet {
-            if #available(OSX 10.15, *) {
-                layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
-            }
-        }
-    }
+	@IBInspectable public var hasContinuousCorners: Bool = true {
+		didSet {
+			if #available(OSX 10.15, *) {
+				layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
+			}
+		}
+	}
 
 	@IBInspectable public var borderWidth: Double = 0 {
 		didSet {
@@ -198,9 +198,9 @@ open class CustomButton: NSButton {
 		layer?.borderColor = isOn ? activeBorderColor.cgColor : borderColor.cgColor
 		layer?.shadowColor = isOn ? (activeShadowColor?.cgColor ?? shadowColor.cgColor) : shadowColor.cgColor
 
-        if #available(OSX 10.15, *) {
-            layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
-        }
+		if #available(OSX 10.15, *) {
+			layer?.cornerCurve = hasContinuousCorners ? .continuous : .circular
+		}
 
 		titleLayer.alignmentMode = .center
 		titleLayer.contentsScale = window?.backingScaleFactor ?? 2


### PR DESCRIPTION
G'day @sindresorhus! Thanks so much for all of your open source work. I recently started learning how to write macOS apps from scratch and your code has been extremely valuable to study! 😁

For your consideration, this PR proposes adding another property to this button class that enables setting the type of corner rounding curve to use [Apple's classic "squircle" style](https://99percentinvisible.org/article/circling-square-designing-squircles-instead-rounded-rectangles/) that was introduced as a public API in macOS 10.15.

Seeing as this is now the default curve style in Big Sur, I've set this property to `true` by default, but I'm happy to change it if this is considered a breaking change.

Please let me know if this PR is good as-is, or if you need me to change anything (Or if you don't need it at all! XD)

Thanks! Have a great day!
